### PR TITLE
Fix external delegate build issue on Windows

### DIFF
--- a/tensorflow/lite/delegates/external/external_delegate.cc
+++ b/tensorflow/lite/delegates/external/external_delegate.cc
@@ -146,14 +146,12 @@ ExternalDelegateWrapper::ExternalDelegateWrapper(
     external_delegate_ = external_lib_.create(ckeys.data(), cvalues.data(),
                                               ckeys.size(), nullptr);
     if (external_delegate_) {
-      wrapper_delegate_ = {
-          .data_ = reinterpret_cast<void*>(this),
-          .Prepare = DelegatePrepare,
-          .CopyFromBufferHandle = nullptr,
-          .CopyToBufferHandle = nullptr,
-          .FreeBufferHandle = nullptr,
-          .flags = external_delegate_->flags,
-      };
+      wrapper_delegate_.data_ = reinterpret_cast<void*>(this);
+      wrapper_delegate_.Prepare = DelegatePrepare;
+      wrapper_delegate_.CopyFromBufferHandle = nullptr;
+      wrapper_delegate_.CopyToBufferHandle = nullptr;
+      wrapper_delegate_.FreeBufferHandle = nullptr;
+      wrapper_delegate_.flags = external_delegate_->flags;
       if (external_delegate_->CopyFromBufferHandle) {
         wrapper_delegate_.CopyFromBufferHandle = DelegateCopyFromBufferHandle;
       }

--- a/tensorflow/lite/interpreter_builder.cc
+++ b/tensorflow/lite/interpreter_builder.cc
@@ -180,8 +180,8 @@ TFLITE_ATTRIBUTE_WEAK Interpreter::TfLiteDelegatePtr AcquireFlexDelegate() {
   // Load TF_AcquireFlexDelegate() from _pywrap_tensorflow_internal.so if it is
   // available.
 #if defined(_WIN32)
-  const wchar_t* filename_pywrap_tensorflow_internal =
-      L"_pywrap_tensorflow_internal.pyd";
+  const char* filename_pywrap_tensorflow_internal =
+      "_pywrap_tensorflow_internal.pyd";
 #elif defined(__APPLE__)
   const char* filename_pywrap_tensorflow_internal =
       "python/_pywrap_tensorflow_internal.so";
@@ -194,7 +194,7 @@ TFLITE_ATTRIBUTE_WEAK Interpreter::TfLiteDelegatePtr AcquireFlexDelegate() {
 #if defined(_WIN32)
   if (lib_tf_internal == nullptr) {
     lib_tf_internal = SharedLibrary::LoadLibrary(
-        L"_pywrap_tensorflow_interpreter_wrapper.pyd");
+        "_pywrap_tensorflow_interpreter_wrapper.pyd");
   }
 #endif
   if (lib_tf_internal) {

--- a/tensorflow/lite/shared_library.h
+++ b/tensorflow/lite/shared_library.h
@@ -29,8 +29,8 @@ namespace tflite {
 class SharedLibrary {
  public:
 #if defined(_WIN32)
-  static inline void* LoadLibrary(const wchar_t* lib) {
-    return ::LoadLibraryW(lib);
+  static inline void* LoadLibrary(const char* lib) {
+    return ::LoadLibrary(lib);
   }
   static inline void* GetLibrarySymbol(void* handle, const char* symbol) {
     return reinterpret_cast<void*>(


### PR DESCRIPTION
This fix is required to build `tensorflowlite_c` and `external_delegate_obj` on my windows OS. My environment has bazel 5.1.0 and Visual Studio 2019.

@mattsoulanille @honry, please take a look. Thanks.